### PR TITLE
bem-graph: hash-set: Fix forEach context passing

### DIFF
--- a/bem-graph.js
+++ b/bem-graph.js
@@ -5713,7 +5713,7 @@ module.exports = function hashSet(hashFn) {
          */
         forEach(callbackFn, thisArg) {
             this._map.forEach(function(value) {
-                callbackFn(value, value, this);
+                callbackFn.call(thisArg, value, value, this);
             }, thisArg);
         }
         /**

--- a/bem-graph.js
+++ b/bem-graph.js
@@ -5704,7 +5704,7 @@ module.exports = function hashSet(hashFn) {
          *
          * Callback is invoked with three arguments:
          *   * the element value
-         *   * the element value
+         *   * the element key
          *   * the Set object being traversed
          *
          * @param {function} callbackFn — function to execute for each element.
@@ -5712,9 +5712,7 @@ module.exports = function hashSet(hashFn) {
          *                           to forEach, it will be used as the this value for each callback.
          */
         forEach(callbackFn, thisArg) {
-            this._map.forEach(function(value) {
-                callbackFn.call(thisArg, value, value, this);
-            }, thisArg);
+            this._map.forEach((value, key) => callbackFn.call(thisArg, value, key, this));
         }
         /**
          * Returns a new Iterator object that contains the values for each element in the Set object in insertion order.


### PR DESCRIPTION
https://github.com/blond/hash-set/pull/45/files

Fix `forEach(this.foo, this)` case.

~~[кстати, почему бэм-граф подключён путём вендоринга, а не зависимостью?](https://github.com/zxqfox/gather-reverse-deps/issues/5)~~